### PR TITLE
Fix: searching

### DIFF
--- a/limix_sphinx_theme/bootstrap-limix/layout.html
+++ b/limix_sphinx_theme/bootstrap-limix/layout.html
@@ -2,12 +2,6 @@
 
 {% block extrahead %}
 {% if not embedded %}
-<script src="//code.jquery.com/jquery-3.3.1.min.js"
-        integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8="
-        crossorigin="anonymous"></script>
-<script>
-    window.jQuery || document.write("<script src=\"{{ pathto('_static/jquery-3.3.1.min.js', 1) }}\"><\/script>");
-</script>
 <script type="text/javascript" src="{{ pathto('_static/copybutton.js', 1) }}"></script>
 {% endif %}
 {% endblock %}


### PR DESCRIPTION
JQuery in layout.html is redundant in relation to the base theme and causes problems with the search control working. Because the Limix theme base on RTD I suggest removing jquery in this theme after all.